### PR TITLE
Revert "Add Darwin/AMD"

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -28,8 +28,7 @@
     "arch": [
       "linux/amd64",
       "linux/arm64",
-      "darwin/arm64",
-      "darwin/amd64"
+      "darwin/arm64"
     ]
   },
   "path": "module.tar.gz",


### PR DESCRIPTION
Reverts viam-soleng/viam-modbus#19 due to cloud build not supporting darwin/amd64